### PR TITLE
Fix a simple thing that just annoys me. (dont have to merge this is my preference)

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ require('./api');
 
 // [Clients]
 const discordClient = new QbotClient();
-discordClient.login(process.env.token);
+discordClient.login(process.env.DISCORD_TOKEN);
 const robloxClient = new RobloxClient({ credentials: { cookie: process.env.ROBLOX_COOKIE } });
 let robloxGroup: Group = null;
 (async () => {


### PR DESCRIPTION
Yeah, so the roblox cookie in the .env is under ROBLOX_COOKIE and the token is under token=.

This PR just makes it so DISCORD_TOKEN replaces token in the .env to match the grammar of the cookie.

(this also requires a update of the docs, but they are not open source so I cannot do that)

no pressure in accepting! this is just something that i feel should be changed.