### PR TITLE
Add page-based help menu support

### DIFF
--- a/src/handlers/locale.ts
+++ b/src/handlers/locale.ts
@@ -489,3 +489,25 @@ export const getJoinRequestsEmbed = (joinRequests: GroupJoinRequest[]): MessageE
 
     return embed;
 }
+
+export const getCommandEmbedByModule = (modules: { [key: string]: Command[] }, module: string): MessageEmbed => {
+    let formattedModuleString = module.replace('-', ' ').split(' ').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+    let commands: Command[] = modules[module];
+    let description = "";
+    for(let i = 0; i < commands.length; i++) {
+        description += `\`${commands[i].trigger}\` - ${commands[i].description}\n`;
+    }
+    const embed = new MessageEmbed();
+    embed.setAuthor(formattedModuleString, infoIconUrl);
+    embed.setColor(mainColor);
+    embed.setDescription(description);
+    return embed;
+}
+
+export const getTimesUpEmbed = (): MessageEmbed => {
+    const embed = new MessageEmbed();
+    embed.setAuthor("Time is Up", infoIconUrl);
+    embed.setColor(mainColor);
+    embed.setDescription("Your time for this embed is up, if you wish to continue, please return the command");
+    return embed;
+}


### PR DESCRIPTION
This adds the ability for the help command to have a "paging" system

I remember seeing this in the suggestions channel, so after when I was available to code it, I did

I wanted to still have support for the old method, but I was thinking on how I should implement it

I decided that in order to implement this feature, I did the following

> Allow the help command accept an argument called "page-based", and if a value is given, the help embed is page based, else, it's regular
> Using reactions

There's no bugs as far as I know on this

Also, if you'd want me to implement it a different way (like it being a config value instead of the argument, or using buttons instead of reactions), just comment it below

Have a good day/night