### PR TITLE
Fix Disabling legacyCommands

### DIFF
--- a/src/handlers/handleLegacyCommand.ts
+++ b/src/handlers/handleLegacyCommand.ts
@@ -25,7 +25,7 @@ const parseCommand = (s: string): [string, Args] | null => {
 }
 
 const handleLegacyCommand = async (message: Message) => {
-    if(!config.legacyCommands) return;
+    if(!config.legacyCommands.enabled) return;
     if(message.channel.type === 'DM') return;
     const out = parseCommand(message.content);
     if(!out) return;


### PR DESCRIPTION
The function only checked if the legacyCommands object exists within the config, which was always true, but not if legacyCommands are enabled.