### PR TITLE
Fix Wall Ads Check

### DIFF
--- a/src/events/wall.ts
+++ b/src/events/wall.ts
@@ -7,7 +7,7 @@ const checkWallForAds = async () => {
     try {
         const group = await robloxClient.getGroup(config.groupId);
         const posts = await group.getWallPosts({ limit: 100, sortOrder: 'Desc' });
-        posts.data.forEach((post: any, index) => {
+        posts.data?.forEach((post: any, index) => {
             setTimeout(async () => {
                 if(/https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&\/\/=]*)/gm.test(post.body)) {
                     await group.deleteWallPost(post.id);


### PR DESCRIPTION
`posts.data` may be undefined, so the code will short-circuit if it is undefined instead of erroring.