### PR TITLE
Add help page support & XP system changes

### DIFF
--- a/src/commands/information/help.ts
+++ b/src/commands/information/help.ts
@@ -6,7 +6,20 @@ import {
     getCommandInfoEmbed,
     getCommandListEmbed,
     getCommandNotFoundEmbed,
+    getCommandEmbedByModule,
+    getTimesUpEmbed
 } from '../../handlers/locale';
+
+import {
+    Message,
+    MessageEmbed,
+    MessageActionRow,
+    MessageButton,
+    MessageButtonStyleResolvable,
+    Interaction,
+    ButtonInteraction,
+    CommandInteraction
+} from 'discord.js';
 
 class HelpCommand extends Command {
     constructor() {
@@ -26,6 +39,13 @@ class HelpCommand extends Command {
         });
     }
 
+    addButton(messageData : any, id : string, label : string, style : MessageButtonStyleResolvable) {
+        let components = messageData.components || [];
+        let newComponent = new MessageActionRow().addComponents(new MessageButton().setCustomId(id).setLabel(label).setStyle(style));
+        components.push(newComponent);
+        messageData.components = components;
+    }
+
     async run(ctx: CommandContext) {
         const commands = discordClient.commands.map((cmd) => new(cmd));
         if(ctx.args['command-name']) {
@@ -34,7 +54,52 @@ class HelpCommand extends Command {
             return ctx.reply({ embeds: [ getCommandInfoEmbed(command) ] });
         } else {
             const categories = groupBy(commands, (cmd) => cmd.module);
-            return ctx.reply({ embeds: [ getCommandListEmbed(categories) ] });
+            const keys = Object.keys(categories);
+            const embeds = [];
+            for(let i = 0; i < keys.length; i++) {
+                embeds.push({
+                    module: keys[i].replace('-', ' ').split(' ').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' '),
+                    embed: getCommandEmbedByModule(categories, keys[i])
+                });
+            }
+            let index = 0;
+            let previousModule = (embeds[index - 1] || embeds[embeds.length - 1]).module;
+            let nextModule = (embeds[index + 1] || embeds[0]).module;
+            let oldDescription = embeds[index].embed.description;
+            const msgData = { embeds: [ embeds[index].embed.setDescription(embeds[index].embed.description += `\n**Previous Module**: ${previousModule} ; **Next Module**: ${nextModule}`) ], components: []};
+            this.addButton(msgData, "previousButton", "Previous Module", "PRIMARY");
+            this.addButton(msgData, "nextButton", "Next Module", "PRIMARY");
+            let msg = await ctx.reply(msgData);
+            embeds[index].embed.setDescription(oldDescription);
+            const filter = (filterInteraction : Interaction) => {
+                if(!filterInteraction.isButton()) return false;
+                if(filterInteraction.user.id !== ctx.user.id) return false;
+                return true;
+            }
+            const componentCollector = (msg as Message).createMessageComponentCollector({filter: filter, time: 120000});
+            componentCollector.on('collect', async collectedButton => {
+                let button = collectedButton as ButtonInteraction;
+                if(button.customId === "previousButton") {
+                    index = embeds.findIndex(embedObject => embedObject.module === previousModule);
+                    previousModule = (embeds[index - 1] || embeds[embeds.length - 1]).module;
+                    nextModule = (embeds[index + 1] || embeds[0]).module;
+                    oldDescription = embeds[index].embed.description;
+
+                } else {
+                    index = embeds.findIndex(embedObject => embedObject.module === nextModule);
+                    previousModule = (embeds[index - 1] || embeds[embeds.length - 1]).module;
+                    nextModule = (embeds[index + 1] || embeds[0]).module;
+                    oldDescription = embeds[index].embed.description;
+                }
+                await (ctx.subject as CommandInteraction).editReply({ embeds: [ embeds[index].embed.setDescription(embeds[index].embed.description += `\n**Previous Module**: ${previousModule} ; **Next Module**: ${nextModule}`) ] });
+                embeds[index].embed.setDescription(oldDescription);
+                await button.reply({content: "ㅤ"});
+                await button.deleteReply();
+            });
+            componentCollector.on('end', async () => {
+                await (msg as Message).reply({ embeds: [ getTimesUpEmbed() ] });
+                return;
+            });
         }
     }
 }

--- a/src/commands/xp/addxp.ts
+++ b/src/commands/xp/addxp.ts
@@ -2,6 +2,8 @@ import { discordClient, robloxClient, robloxGroup } from '../../main';
 import { CommandContext } from '../../structures/addons/CommandAddons';
 import { Command } from '../../structures/Command';
 import {
+    getXPSystemNotEnabledEmbed,
+    getNoDatabaseEmbed,
     getInvalidRobloxUserEmbed,
     getRobloxUserIsNotMemberEmbed,
     getUnexpectedErrorEmbed,
@@ -59,7 +61,8 @@ class AddXPCommand extends Command {
     }
 
     async run(ctx: CommandContext) {
-        if(!config.database.enabled) return ctx.reply({ embeds: [ getUnexpectedErrorEmbed() ] });
+        if(!config.xpSystem.enabled) return ctx.reply({ embeds: [ getXPSystemNotEnabledEmbed() ] });
+        if(!config.database.enabled) return ctx.reply({ embeds: [ getNoDatabaseEmbed() ] });
         let enoughForRankUp: boolean;
         let robloxUser: User | PartialUser;
         try {

--- a/src/commands/xp/addxp.ts
+++ b/src/commands/xp/addxp.ts
@@ -61,7 +61,7 @@ class AddXPCommand extends Command {
     }
 
     async run(ctx: CommandContext) {
-        if(!config.xpSystem.enabled) return ctx.reply({ embeds: [ getXPSystemNotEnabledEmbed() ] });
+        if(!config.xpSystem.enabled) return ctx.reply({ embeds: [ getXPSystemNotEnabledEmbed() ] })
         if(!config.database.enabled) return ctx.reply({ embeds: [ getNoDatabaseEmbed() ] });
         let enoughForRankUp: boolean;
         let robloxUser: User | PartialUser;

--- a/src/commands/xp/addxp.ts
+++ b/src/commands/xp/addxp.ts
@@ -61,7 +61,7 @@ class AddXPCommand extends Command {
     }
 
     async run(ctx: CommandContext) {
-        if(!config.xpSystem.enabled) return ctx.reply({ embeds: [ getXPSystemNotEnabledEmbed() ] })
+        if(!config.xpSystem.enabled) return ctx.reply({ embeds: [ getXPSystemNotEnabledEmbed() ] });
         if(!config.database.enabled) return ctx.reply({ embeds: [ getNoDatabaseEmbed() ] });
         let enoughForRankUp: boolean;
         let robloxUser: User | PartialUser;

--- a/src/commands/xp/removexp.ts
+++ b/src/commands/xp/removexp.ts
@@ -2,6 +2,8 @@ import { discordClient, robloxClient, robloxGroup } from '../../main';
 import { CommandContext } from '../../structures/addons/CommandAddons';
 import { Command } from '../../structures/Command';
 import {
+    getXPSystemNotEnabledEmbed,
+    getNoDatabaseEmbed,
     getInvalidRobloxUserEmbed,
     getRobloxUserIsNotMemberEmbed,
     getUnexpectedErrorEmbed,
@@ -56,7 +58,8 @@ class RemoveXPCommand extends Command {
     }
 
     async run(ctx: CommandContext) {
-        if(!config.database.enabled) return ctx.reply({ embeds: [ getUnexpectedErrorEmbed() ] });
+        if(!config.xpSystem.enabled) return ctx.reply({ embeds: [ getXPSystemNotEnabledEmbed() ] });
+        if(!config.database.enabled) return ctx.reply({ embeds: [ getNoDatabaseEmbed() ] });
 
         let robloxUser: User | PartialUser;
         try {

--- a/src/commands/xp/xpleaderboard.ts
+++ b/src/commands/xp/xpleaderboard.ts
@@ -1,0 +1,40 @@
+import { CommandContext } from '../../structures/addons/CommandAddons';
+import { Command } from '../../structures/Command';
+import { User } from 'bloxy/dist/structures';
+import { getLinkedRobloxUser } from '../../handlers/accountLinks';
+import { config } from '../../config';
+import {
+    getXPSystemNotEnabledEmbed,
+    getNoDatabaseEmbed,
+    getUnexpectedErrorEmbed,
+    getNoUsersWithXPEmbed,
+    getXPLeaderBoardEmbed
+} from '../../handlers/locale';
+import { provider } from '../../database/router';
+
+class XPLeaderBoardCommand extends Command {
+    constructor() {
+        super({
+            trigger: "xpleaderboard",
+            description: "Shows the XP leaderboard",
+            type: "ChatInput",
+            module: "xp"
+        });
+    }
+
+    async run(ctx: CommandContext) {
+        if(!config.xpSystem.enabled) return ctx.reply({ embeds: [ getXPSystemNotEnabledEmbed() ] });
+        if(!config.database.enabled) return ctx.reply({ embeds: [ getNoDatabaseEmbed() ] });
+        let users;
+        try {
+            users = await provider.findTopUsers();
+        } catch(e) {
+            console.log(e);
+            return ctx.reply({ embeds: [ getUnexpectedErrorEmbed() ] });
+        }
+        if(users.length === 0) return ctx.reply({ embeds: [ getNoUsersWithXPEmbed() ] });
+        return await ctx.reply({ embeds: [ await getXPLeaderBoardEmbed(users) ] });
+    }
+}
+
+export default XPLeaderBoardCommand;

--- a/src/commands/xp/xprankup.ts
+++ b/src/commands/xp/xprankup.ts
@@ -2,6 +2,8 @@ import { discordClient, robloxClient, robloxGroup } from '../../main';
 import { CommandContext } from '../../structures/addons/CommandAddons';
 import { Command } from '../../structures/Command';
 import {
+    getXPSystemNotEnabledEmbed,
+    getNoDatabaseEmbed,
     getInvalidRobloxUserEmbed,
     getRobloxUserIsNotMemberEmbed,
     getUnexpectedErrorEmbed,
@@ -40,7 +42,8 @@ class XPRankupCommand extends Command {
     }
 
     async run(ctx: CommandContext) {
-        if(!config.database.enabled) return ctx.reply({ embeds: [ getUnexpectedErrorEmbed() ] });
+        if(!config.xpSystem.enabled) return ctx.reply({ embeds: [ getXPSystemNotEnabledEmbed() ] });
+        if(!config.database.enabled) return ctx.reply({ embeds: [ getNoDatabaseEmbed() ] });
 
         let robloxUser: User | PartialUser;
         try {

--- a/src/database/mongodb.ts
+++ b/src/database/mongodb.ts
@@ -18,6 +18,8 @@ class MongoDBProvider extends DatabaseProvider {
         if(config.database.enabled) connect(process.env.DB_URI).catch(console.error);
     }
 
+    rawUserDatabase = User;
+
     async findUser(robloxId: string): Promise<DatabaseUser> {
         let userData = await User.findOne({ robloxId });
         if(!userData) {
@@ -43,6 +45,17 @@ class MongoDBProvider extends DatabaseProvider {
             userData[key] = data[key];
         });
         return await userData.save();
+    }
+
+    async findTopUsers(): Promise<DatabaseUser[]> {
+        const usersWithXP = (await User.find({}).sort({ xp: -1 })).filter(userData => userData.xp > 0);
+        const users = [];
+        let increment;
+        if(usersWithXP.length >= 10) { increment = 10 } else { increment = usersWithXP.length; }
+        for(let i = 0; i < increment; i++) {
+            users.push(usersWithXP[i]);
+        }
+        return users;
     }
 }
 

--- a/src/handlers/locale.ts
+++ b/src/handlers/locale.ts
@@ -569,3 +569,57 @@ export const getSuccessfulGroupUnbanEmbed = (user: User | PartialUser) : Message
     embed.setDescription(`**${user.name}** has successfully been unbanned from the group.`);
     return embed;
 }
+
+export const getCommandEmbedByModule = (modules: { [key: string]: Command[] }, module: string): MessageEmbed => {
+    let formattedModuleString = module.replace('-', ' ').split(' ').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+    let commands: Command[] = modules[module];
+    let description = "";
+    for(let i = 0; i < commands.length; i++) {
+        description += `\`${commands[i].trigger}\` - ${commands[i].description}\n`;
+    }
+    const embed = new MessageEmbed();
+    embed.setAuthor(formattedModuleString, infoIconUrl);
+    embed.setColor(mainColor);
+    embed.setDescription(description);
+    return embed;
+}
+
+export const getTimesUpEmbed = (): MessageEmbed => {
+    const embed = new MessageEmbed();
+    embed.setAuthor("Time is Up", infoIconUrl);
+    embed.setColor(mainColor);
+    embed.setDescription("Your time for this embed is up, if you wish to continue, please return the command");
+    return embed;
+}
+
+export const getNoUsersWithXPEmbed = (): MessageEmbed => {
+    const embed = new MessageEmbed();
+    embed.setAuthor("No Users with XP", xmarkIconUrl);
+    embed.setColor(redColor);
+    embed.setDescription("There's currently no users with XP with this Qbot installaion, perhaps you should add some XP before seeing the leaderboard");
+    return embed;
+}
+
+export const getXPLeaderBoardEmbed = async (users: DatabaseUser[]) : Promise<MessageEmbed> => {
+    const embed = new MessageEmbed();
+    embed.setAuthor("XP Leadboard", infoIconUrl);
+    embed.setColor(mainColor);
+    let description = "";
+    let numPlace = 1;
+    for(let i = 0; i < users.length; i++) {
+        let endingPlace;
+        if(numPlace === 1) { endingPlace = "st" } else if(numPlace === 2) { endingPlace = "nd" } else if(numPlace === 3) { endingPlace = "rd" } else { endingPlace = "th" };
+        description += `**${numPlace}${endingPlace}** - ${(await robloxClient.getUsernameFromUserId(users[i].robloxId)).name} - ${users[i].xp}\n`;
+        numPlace++;
+    }
+    embed.setDescription(description);
+    return embed;
+}
+
+export const getXPSystemNotEnabledEmbed = () : MessageEmbed => {
+    const embed = new MessageEmbed();
+    embed.setAuthor("XP Module Disabled", xmarkIconUrl);
+    embed.setColor(redColor);
+    embed.setDescription("The XP module is currently not enabled, please enable it in order to use this command");
+    return embed;
+}


### PR DESCRIPTION
(Remake of #110, but with the original concepts not included in other PRs or commits)

Changes

* Adds the ability for the help command to have pagination support
* Add XP leaderboard command
* Adds a check that if the XP system is disabled (``config.xpSystem.enabled === false``) then block usage of all XP commands
* Change the XP command's no database embed to the actual no database embed in locale.ts
* Removes old help command's functionality