### PR TITLE
Add Reason for Bans to Database

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -54,6 +54,7 @@ if(config.api) {
                 suspendedUntil: userData.suspendedUntil,
                 unsuspendRank: userData.unsuspendRank,
                 isBanned: userData.isBanned,
+                reasonForBan: userData.reasonForBan,
             })
         } catch (err) {
             return res.send({ success: false, msg: 'Failed to get information.' });

--- a/src/api.ts
+++ b/src/api.ts
@@ -260,7 +260,7 @@ if(config.api) {
             const userData = await provider.findUser(robloxMember.id.toString());
             const xp = Number(userData.xp) - Number(amount);
 
-            logAction('Remove XP', 'API Action', null, robloxUser, null, null, null, `${userData.xp} → ${xp} (+${Number(amount)})`);
+            logAction('Remove XP', 'API Action', null, robloxUser, null, null, null, `${userData.xp} → ${xp} (-${Number(amount)})`);
             await provider.updateUser(robloxMember.id.toString(), { xp });
 
             return res.send({ success: true });

--- a/src/commands/admin/groupban.ts
+++ b/src/commands/admin/groupban.ts
@@ -91,7 +91,8 @@ class GroupBanCommand extends Command {
         
         try {
             await provider.updateUser(robloxUser.id.toString(), {
-                isBanned: true
+                isBanned: true,
+				reasonForBan: `${ctx.args['reason']}`
             });
             if(robloxMember) await robloxGroup.kickMember(robloxUser.id);
             logAction('Group Ban', ctx.user, ctx.args['reason'], robloxUser);

--- a/src/commands/admin/groupban.ts
+++ b/src/commands/admin/groupban.ts
@@ -92,7 +92,7 @@ class GroupBanCommand extends Command {
         try {
             await provider.updateUser(robloxUser.id.toString(), {
                 isBanned: true,
-				reasonForBan: `${ctx.args['reason']}`
+		reasonForBan: `${ctx.args['reason']}`
             });
             if(robloxMember) await robloxGroup.kickMember(robloxUser.id);
             logAction('Group Ban', ctx.user, ctx.args['reason'], robloxUser);

--- a/src/database/mongodb.ts
+++ b/src/database/mongodb.ts
@@ -9,7 +9,8 @@ const User = model('User', new Schema({
     xp: Number,
     suspendedUntil: Date,
     unsuspendRank: Number,
-    isBanned: Boolean
+    isBanned: Boolean,
+    reasonForBan: String,
 }));
 
 class MongoDBProvider extends DatabaseProvider {

--- a/src/handlers/locale.ts
+++ b/src/handlers/locale.ts
@@ -451,6 +451,7 @@ export const getPartialUserInfoEmbed = async (user: User | PartialUser, data: Da
         .setTimestamp()
         .addField('Role', 'Guest (0)', true)
         .addField('Banned', data.isBanned ? `✅` : '❌', true)
+        .addField('Reason', `${data.reasonForBan}` || `N/A`, true)
 
     return embed;
 }
@@ -468,7 +469,8 @@ export const getUserInfoEmbed = async (user: User | PartialUser, member: GroupMe
         .addField('XP', data.xp.toString() || '0', true)
         .addField('Suspended', data.suspendedUntil ? `✅ (<t:${Math.round(data.suspendedUntil.getTime() / 1000)}:R>)` : '❌', true)
         .addField('Banned', data.isBanned ? `✅` : '❌', true);
-
+        .addField('Reason', `${data.reasonForBan}` || `N/A`, true)
+    
     return embed;
 }
 

--- a/src/handlers/locale.ts
+++ b/src/handlers/locale.ts
@@ -451,7 +451,7 @@ export const getPartialUserInfoEmbed = async (user: User | PartialUser, data: Da
         .setTimestamp()
         .addField('Role', 'Guest (0)', true)
         .addField('Banned', data.isBanned ? `✅` : '❌', true)
-        .addField('Reason', `${data.reasonForBan}` || `N/A`, true)
+        .addField('Reason', data.reasonForBan ? `${data.reasonForBan}`: `N/A`, true)
 
     return embed;
 }
@@ -469,7 +469,7 @@ export const getUserInfoEmbed = async (user: User | PartialUser, member: GroupMe
         .addField('XP', data.xp.toString() || '0', true)
         .addField('Suspended', data.suspendedUntil ? `✅ (<t:${Math.round(data.suspendedUntil.getTime() / 1000)}:R>)` : '❌', true)
         .addField('Banned', data.isBanned ? `✅` : '❌', true);
-        .addField('Reason', `${data.reasonForBan}` || `N/A`, true)
+        .addField('Reason', data.reasonForBan ? `${data.reasonForBan}`: `N/A`, true)
     
     return embed;
 }

--- a/src/structures/types.d.ts
+++ b/src/structures/types.d.ts
@@ -339,5 +339,9 @@ export declare type DatabaseUser = {
     /**
      * Is the user banned from the group?
      */
-    isBanned: boolean
+    isBanned: boolean;
+    /**
+	 * Reason for the ban? (If banned)
+	 */
+	reasonForBan?: string;
 }


### PR DESCRIPTION
When a user is group banned, the reason is currently only being logged in an embed. This pull requests adds the reason to MongoDB and will return the reason for the ban when /info is run.