### PR TITLE
Add role locking support

### DIFF
--- a/src/commands/ranking/demote.ts
+++ b/src/commands/ranking/demote.ts
@@ -123,22 +123,31 @@ class DemoteCommand extends Command {
                 if(config.lockedRanks.find(v => v === role.rank)) continue;
                 break;
             }
-            let msgData = { embeds: [ getRankLockedEmbed(oldRole, role.name) ] };
+            let msgData = { embeds: [ getRankLockedEmbed(oldRole, role.name) ], components: [] };
             this.addButton(msgData, "continueButton", "Continue", "SUCCESS");
             this.addButton(msgData, "cancelButton", "Cancel", "DANGER");
-            let msg = await ctx.reply(msgData);
+            let msg = await ctx.reply(msgData) as Message;
             const filter = (filterInteraction : Interaction) => {
                 if(!filterInteraction.isButton()) return false;
                 if(filterInteraction.user.id !== ctx.user.id) return false;
                 return true;
             }
-            const componentCollector = (msg as Message).createMessageComponentCollector({filter: filter, time: 60000, max: 1});
+            const componentCollector = msg.createMessageComponentCollector({filter: filter, time: 60000, max: 1});
             componentCollector.on('end', async collectedButtons => {
                 if(collectedButtons.size === 0) {
                     if(ctx.subject instanceof CommandInteraction) {
-                        await (ctx.subject as CommandInteraction).editReply({ embeds: [ getCancelledEmbed() ] });
+                        msg = await (ctx.subject as CommandInteraction).editReply({ embeds: [ getCancelledEmbed() ] }) as Message;
                     } else {
-                        await (msg as Message).edit({ embeds: [ getCancelledEmbed() ] });
+                        msg = await msg.edit({ embeds: [ getCancelledEmbed() ] });
+                    }
+                    for(let i = 0; i < msg.components.length; i++) {
+                        msg.components[i].components[0].setDisabled(true);
+                    }
+                    msgData = { embeds: [...msg.embeds], components: [...msg.components] };
+                    if(ctx.subject instanceof CommandInteraction) {
+                        await (ctx.subject as CommandInteraction).editReply(msgData);   
+                    } else {
+                        await msg.edit(msgData);
                     }
                     return;
                 }
@@ -147,28 +156,37 @@ class DemoteCommand extends Command {
                     try {
                         await robloxGroup.updateMember(robloxUser.id, role.id);
                         if(ctx.subject instanceof CommandInteraction) {
-                            await (ctx.subject as CommandInteraction).editReply({ embeds: [ await getSuccessfulDemotionEmbed(robloxUser, role.name) ]})
+                            msg = await (ctx.subject as CommandInteraction).editReply({ embeds: [ await getSuccessfulDemotionEmbed(robloxUser, role.name) ]}) as Message;
                         } else {
-                            await (msg as Message).edit({ embeds: [ await getSuccessfulDemotionEmbed(robloxUser, role.name) ]})
+                            msg = await msg.edit({ embeds: [ await getSuccessfulDemotionEmbed(robloxUser, role.name) ]});
                         }
                         logAction('Demote', ctx.user, ctx.args['reason'], robloxUser, `${robloxMember.role.name} (${robloxMember.role.rank}) → ${role.name} (${role.rank})`);
                     } catch (err) {
                         console.log(err);
                         if(ctx.subject instanceof CommandInteraction) {
-                            await (ctx.subject as CommandInteraction).editReply({ embeds: [ getUnexpectedErrorEmbed() ]});
+                            msg = await (ctx.subject as CommandInteraction).editReply({ embeds: [ getUnexpectedErrorEmbed() ]}) as Message;
                         } else {
-                            await (msg as Message).edit({ embeds: [ getUnexpectedErrorEmbed() ]});
+                            msg = await msg.edit({ embeds: [ getUnexpectedErrorEmbed() ]});
                         }
                     }
                 } else {
                     if(ctx.subject instanceof CommandInteraction) {
-                        await (ctx.subject as CommandInteraction).editReply({ embeds: [ getCancelledEmbed() ] });   
+                        msg = await (ctx.subject as CommandInteraction).editReply({ embeds: [ getCancelledEmbed() ] }) as Message;
                     } else {
-                        await (msg as Message).edit({ embeds: [ getCancelledEmbed() ] })
+                        msg = await msg.edit({ embeds: [ getCancelledEmbed() ] });
                     }
                 }
                 await button.reply({content: "ㅤ"});
                 await button.deleteReply();
+                for(let i = 0; i < msg.components.length; i++) {
+                    msg.components[i].components[0].setDisabled(true);
+                }
+                msgData = { embeds: [...msg.embeds], components: [...msg.components] };
+                if(ctx.subject instanceof CommandInteraction) {
+                    await (ctx.subject as CommandInteraction).editReply(msgData);   
+                } else {
+                    await msg.edit(msgData);
+                }
                 return;
             });
         } else {

--- a/src/commands/ranking/demote.ts
+++ b/src/commands/ranking/demote.ts
@@ -10,6 +10,8 @@ import {
     getRoleNotFoundEmbed,
     getVerificationChecksFailedEmbed,
     getUserSuspendedEmbed,
+    getRankLockedEmbed,
+    getCancelledEmbed,
 } from '../../handlers/locale';
 import { config } from '../../config';
 import { User, PartialUser, GroupMember } from 'bloxy/dist/structures';
@@ -18,7 +20,17 @@ import { logAction } from '../../handlers/handleLogging';
 import { getLinkedRobloxUser } from '../../handlers/accountLinks';
 import { provider } from '../../database/router';
 
-class PromoteCommand extends Command {
+import {
+    Message,
+    Interaction,
+    ButtonInteraction,
+    MessageButton,
+    MessageButtonStyleResolvable,
+    MessageActionRow,
+    CommandInteraction,
+} from 'discord.js';
+
+class DemoteCommand extends Command {
     constructor() {
         super({
             trigger: 'demote',
@@ -48,6 +60,13 @@ class PromoteCommand extends Command {
                 }
             ]
         });
+    }
+
+    addButton(messageData : any, id : string, label : string, style : MessageButtonStyleResolvable) {
+        let components = messageData.components || [];
+        let newComponent = new MessageActionRow().addComponents(new MessageButton().setCustomId(id).setLabel(label).setStyle(style));
+        components.push(newComponent);
+        messageData.components = components;
     }
 
     async run(ctx: CommandContext) {
@@ -82,7 +101,7 @@ class PromoteCommand extends Command {
 
         const groupRoles = await robloxGroup.getRoles();
         const currentRoleIndex = groupRoles.findIndex((role) => role.rank === robloxMember.role.rank);
-        const role = groupRoles[currentRoleIndex - 1];
+        let role = groupRoles[currentRoleIndex - 1];
         if(!role.rank || role.rank === 0) return ctx.reply({ embeds: [ getNoRankBelowEmbed() ]});
         if(role.rank > config.maximumRank || robloxMember.role.rank > config.maximumRank) return ctx.reply({ embeds: [ getRoleNotFoundEmbed() ] });
 
@@ -96,15 +115,73 @@ class PromoteCommand extends Command {
             if(userData.suspendedUntil) return ctx.reply({ embeds: [ getUserSuspendedEmbed() ] });
         }
 
-        try {
-            await robloxGroup.updateMember(robloxUser.id, role.id);
-            ctx.reply({ embeds: [ await getSuccessfulDemotionEmbed(robloxUser, role.name) ]})
-            logAction('Demote', ctx.user, ctx.args['reason'], robloxUser, `${robloxMember.role.name} (${robloxMember.role.rank}) → ${role.name} (${role.rank})`);
-        } catch (err) {
-            console.log(err);
-            return ctx.reply({ embeds: [ getUnexpectedErrorEmbed() ]});
+        if(config.lockedRanks.find(v => v === role.rank)) {
+            let oldRole = role.name;
+            for(let i = currentRoleIndex; i >= 0; i--) {
+                role = groupRoles[i - 1];
+                if(!role.rank || role.rank === 0) return ctx.reply({ embeds: [ getNoRankBelowEmbed() ]});
+                if(config.lockedRanks.find(v => v === role.rank)) continue;
+                break;
+            }
+            let msgData = { embeds: [ getRankLockedEmbed(oldRole, role.name) ] };
+            this.addButton(msgData, "continueButton", "Continue", "SUCCESS");
+            this.addButton(msgData, "cancelButton", "Cancel", "DANGER");
+            let msg = await ctx.reply(msgData);
+            const filter = (filterInteraction : Interaction) => {
+                if(!filterInteraction.isButton()) return false;
+                if(filterInteraction.user.id !== ctx.user.id) return false;
+                return true;
+            }
+            const componentCollector = (msg as Message).createMessageComponentCollector({filter: filter, time: 60000, max: 1});
+            componentCollector.on('end', async collectedButtons => {
+                if(collectedButtons.size === 0) {
+                    if(ctx.subject instanceof CommandInteraction) {
+                        await (ctx.subject as CommandInteraction).editReply({ embeds: [ getCancelledEmbed() ] });
+                    } else {
+                        await (msg as Message).edit({ embeds: [ getCancelledEmbed() ] });
+                    }
+                    return;
+                }
+                let button = [...collectedButtons.values()][0] as ButtonInteraction;
+                if(button.customId === "continueButton") {
+                    try {
+                        await robloxGroup.updateMember(robloxUser.id, role.id);
+                        if(ctx.subject instanceof CommandInteraction) {
+                            await (ctx.subject as CommandInteraction).editReply({ embeds: [ await getSuccessfulDemotionEmbed(robloxUser, role.name) ]})
+                        } else {
+                            await (msg as Message).edit({ embeds: [ await getSuccessfulDemotionEmbed(robloxUser, role.name) ]})
+                        }
+                        logAction('Demote', ctx.user, ctx.args['reason'], robloxUser, `${robloxMember.role.name} (${robloxMember.role.rank}) → ${role.name} (${role.rank})`);
+                    } catch (err) {
+                        console.log(err);
+                        if(ctx.subject instanceof CommandInteraction) {
+                            await (ctx.subject as CommandInteraction).editReply({ embeds: [ getUnexpectedErrorEmbed() ]});
+                        } else {
+                            await (msg as Message).edit({ embeds: [ getUnexpectedErrorEmbed() ]});
+                        }
+                    }
+                } else {
+                    if(ctx.subject instanceof CommandInteraction) {
+                        await (ctx.subject as CommandInteraction).editReply({ embeds: [ getCancelledEmbed() ] });   
+                    } else {
+                        await (msg as Message).edit({ embeds: [ getCancelledEmbed() ] })
+                    }
+                }
+                await button.reply({content: "ㅤ"});
+                await button.deleteReply();
+                return;
+            });
+        } else {
+            try {
+                await robloxGroup.updateMember(robloxUser.id, role.id);
+                ctx.reply({ embeds: [ await getSuccessfulDemotionEmbed(robloxUser, role.name) ]})
+                logAction('Demote', ctx.user, ctx.args['reason'], robloxUser, `${robloxMember.role.name} (${robloxMember.role.rank}) → ${role.name} (${role.rank})`);
+            } catch (err) {
+                console.log(err);
+                return ctx.reply({ embeds: [ getUnexpectedErrorEmbed() ]});
+            }
         }
     }
 }
 
-export default PromoteCommand;
+export default DemoteCommand;

--- a/src/commands/ranking/promote.ts
+++ b/src/commands/ranking/promote.ts
@@ -10,6 +10,8 @@ import {
     getRoleNotFoundEmbed,
     getVerificationChecksFailedEmbed,
     getUserSuspendedEmbed,
+    getRankLockedEmbed,
+    getCancelledEmbed,
 } from '../../handlers/locale';
 import { checkActionEligibility } from '../../handlers/verificationChecks';
 import { config } from '../../config';
@@ -17,6 +19,16 @@ import { User, PartialUser, GroupMember } from 'bloxy/dist/structures';
 import { logAction } from '../../handlers/handleLogging';
 import { getLinkedRobloxUser } from '../../handlers/accountLinks';
 import { provider } from '../../database/router';
+
+import {
+    Message,
+    Interaction,
+    ButtonInteraction,
+    MessageButton,
+    MessageButtonStyleResolvable,
+    MessageActionRow,
+    CommandInteraction,
+} from 'discord.js';
 
 class PromoteCommand extends Command {
     constructor() {
@@ -48,6 +60,13 @@ class PromoteCommand extends Command {
                 }
             ]
         });
+    }
+
+    addButton(messageData : any, id : string, label : string, style : MessageButtonStyleResolvable) {
+        let components = messageData.components || [];
+        let newComponent = new MessageActionRow().addComponents(new MessageButton().setCustomId(id).setLabel(label).setStyle(style));
+        components.push(newComponent);
+        messageData.components = components;
     }
 
     async run(ctx: CommandContext) {
@@ -82,7 +101,7 @@ class PromoteCommand extends Command {
 
         const groupRoles = await robloxGroup.getRoles();
         const currentRoleIndex = groupRoles.findIndex((role) => role.rank === robloxMember.role.rank);
-        const role = groupRoles[currentRoleIndex + 1];
+        let role = groupRoles[currentRoleIndex + 1];
         if(!role) return ctx.reply({ embeds: [ getNoRankAboveEmbed() ]});
         if(role.rank > config.maximumRank || robloxMember.role.rank > config.maximumRank) return ctx.reply({ embeds: [ getRoleNotFoundEmbed() ] });
 
@@ -96,13 +115,72 @@ class PromoteCommand extends Command {
             if(userData.suspendedUntil) return ctx.reply({ embeds: [ getUserSuspendedEmbed() ] });
         }
 
-        try {
-            await robloxGroup.updateMember(robloxUser.id, role.id);
-            ctx.reply({ embeds: [ await getSuccessfulPromotionEmbed(robloxUser, role.name) ]});
-            logAction('Promote', ctx.user, ctx.args['reason'], robloxUser, `${robloxMember.role.name} (${robloxMember.role.rank}) → ${role.name} (${role.rank})`);
-        } catch (err) {
-            console.log(err);
-            return ctx.reply({ embeds: [ getUnexpectedErrorEmbed() ]});
+        if(config.lockedRanks.find(v => v === role.rank)) {
+            let oldRole = role.name;
+            for(let i = currentRoleIndex; i < groupRoles.length; i++) {
+                role = groupRoles[i + 1];
+                if(!role) return ctx.reply({ embeds: [ getNoRankAboveEmbed() ]});
+                if(role.rank > config.maximumRank) continue;
+                if(config.lockedRanks.find(v => v === role.rank)) continue;
+                break;
+            }
+            let msgData = { embeds: [ getRankLockedEmbed(oldRole, role.name) ] };
+            this.addButton(msgData, "continueButton", "Continue", "SUCCESS");
+            this.addButton(msgData, "cancelButton", "Cancel", "DANGER");
+            let msg = await ctx.reply(msgData);
+            const filter = (filterInteraction : Interaction) => {
+                if(!filterInteraction.isButton()) return false;
+                if(filterInteraction.user.id !== ctx.user.id) return false;
+                return true;
+            }
+            const componentCollector = (msg as Message).createMessageComponentCollector({filter: filter, time: 60000, max: 1});
+            componentCollector.on('end', async collectedButtons => {
+                if(collectedButtons.size === 0) {
+                    if(ctx.subject instanceof CommandInteraction) {
+                        await (ctx.subject as CommandInteraction).editReply({ embeds: [ getCancelledEmbed() ] });
+                    } else {
+                        await (msg as Message).edit({ embeds: [ getCancelledEmbed() ] });
+                    }
+                    return;
+                }
+                let button = [...collectedButtons.values()][0] as ButtonInteraction;
+                if(button.customId === "continueButton") {
+                    try {
+                        await robloxGroup.updateMember(robloxUser.id, role.id);
+                        if(ctx.subject instanceof CommandInteraction) {
+                            await (ctx.subject as CommandInteraction).editReply({ embeds: [ await getSuccessfulPromotionEmbed(robloxUser, role.name) ]})
+                        } else {
+                            await (msg as Message).edit({ embeds: [ await getSuccessfulPromotionEmbed(robloxUser, role.name) ]})
+                        }
+                        logAction('Promote', ctx.user, ctx.args['reason'], robloxUser, `${robloxMember.role.name} (${robloxMember.role.rank}) → ${role.name} (${role.rank})`);
+                    } catch (err) {
+                        console.log(err);
+                        if(ctx.subject instanceof CommandInteraction) {
+                            await (ctx.subject as CommandInteraction).editReply({ embeds: [ getUnexpectedErrorEmbed() ]});
+                        } else {
+                            await (msg as Message).edit({ embeds: [ getUnexpectedErrorEmbed() ]});
+                        }
+                    }
+                } else {
+                    if(ctx.subject instanceof CommandInteraction) {
+                        await (ctx.subject as CommandInteraction).editReply({ embeds: [ getCancelledEmbed() ] });   
+                    } else {
+                        await (msg as Message).edit({ embeds: [ getCancelledEmbed() ] })
+                    }
+                }
+                await button.reply({content: "ㅤ"});
+                await button.deleteReply();
+                return;
+            });
+        } else {
+            try {
+                await robloxGroup.updateMember(robloxUser.id, role.id);
+                ctx.reply({ embeds: [ await getSuccessfulPromotionEmbed(robloxUser, role.name) ]});
+                logAction('Promote', ctx.user, ctx.args['reason'], robloxUser, `${robloxMember.role.name} (${robloxMember.role.rank}) → ${role.name} (${role.rank})`);
+            } catch (err) {
+                console.log(err);
+                return ctx.reply({ embeds: [ getUnexpectedErrorEmbed() ]});
+            }
         }
     }
 }

--- a/src/commands/ranking/setrank.ts
+++ b/src/commands/ranking/setrank.ts
@@ -10,6 +10,7 @@ import {
     getVerificationChecksFailedEmbed,
     getAlreadyRankedEmbed,
     getUserSuspendedEmbed,
+    getRankLockedEmbed,
 } from '../../handlers/locale';
 import { config } from '../../config';
 import { User, PartialUser, GroupMember } from 'bloxy/dist/structures';
@@ -100,6 +101,8 @@ class SetRankCommand extends Command {
             const userData = await provider.findUser(robloxUser.id.toString());
             if(userData.suspendedUntil) return ctx.reply({ embeds: [ getUserSuspendedEmbed() ] });
         }
+
+        if(config.lockedRanks.find(v => v === role.rank)) return ctx.reply({ embeds: [ getRankLockedEmbed() ] })
 
         try {
             await robloxGroup.updateMember(robloxUser.id, role.id);

--- a/src/config.ts
+++ b/src/config.ts
@@ -61,4 +61,6 @@ export const config: BotConfig = {
         value: 'for commands.',
     },
     status: 'online',
+    deleteWallURLs: false,
+    lockedRanks: []
 }

--- a/src/handlers/locale.ts
+++ b/src/handlers/locale.ts
@@ -569,3 +569,27 @@ export const getSuccessfulGroupUnbanEmbed = (user: User | PartialUser) : Message
     embed.setDescription(`**${user.name}** has successfully been unbanned from the group.`);
     return embed;
 }
+
+export const getRankLockedEmbed = (oldRank?: string, newRank?: string) : MessageEmbed => {
+    if(newRank) {
+        const embed = new MessageEmbed();
+        embed.setAuthor("Rank Locked", infoIconUrl);
+        embed.setColor(mainColor);
+        embed.setDescription(`The rank that you tried to rank this user to (**${oldRank}**) is currently locked, do you wish to rank them to **${newRank}**?`);
+        return embed;
+    } else {
+        const embed = new MessageEmbed();
+        embed.setAuthor("Rank Locked", xmarkIconUrl);
+        embed.setColor(redColor);
+        embed.setDescription("The rank that you tried to rank this user to is currently locked, please try a different rank");
+        return embed;
+    }
+}
+
+export const getCancelledEmbed = () : MessageEmbed => {
+    let embed = new MessageEmbed();
+    embed.setAuthor("Cancelled", infoIconUrl);
+    embed.setColor(mainColor);
+    embed.setDescription("You've successfully cancelled this action");
+    return embed;
+}

--- a/src/structures/types.d.ts
+++ b/src/structures/types.d.ts
@@ -218,6 +218,10 @@ export interface BotConfig {
      * Should the bot delete URLs in your group wall?
      */
     deleteWallURLs: boolean;
+    /**
+     * Are there any locked ranks that the bot shouldn't be able to rank to?
+     */
+    lockedRanks: Array<number>
 }
 
 export declare type CommandPermission = {


### PR DESCRIPTION
This PR adds the ability for one to "lock" roles, thus making it that any ranking commands will refuse to rank people to that role

In case you're curious, here's what the different commands do in case of a locked rank
* For setrank, if one were to supply a locked rank ID, the command will fail
* For promote and demote, if one were to supply a locked rank ID, the command will ask the command author if they want to rank the user to the next rank available

If there are any bugs, please let me know